### PR TITLE
feat(strimzi-version): upgrade strimzi to 0.39.0-kafka-3.5.1

### DIFF
--- a/strimzi-kafka-connect/Dockerfile
+++ b/strimzi-kafka-connect/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/strimzi/kafka:0.27.1-kafka-2.8.1
+FROM quay.io/strimzi/kafka:0.39.0-kafka-3.5.1
 LABEL maintainer="SRE Team <sre@pleo.io>"
 
 USER root:root


### PR DESCRIPTION
Now that we will be using `kafka-3.5.1` we can use latest `strimzi` operator version