### PR TITLE
feat(multi-gitter): add config for sre-5197

### DIFF
--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/README.md
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/README.md
@@ -1,0 +1,32 @@
+# [SRE-5197 : Move from ingress to k8s service for internal traffic](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic)
+
+This folder contains script and configuration used with [`multi-gitter`]() in order to switch to use the internal kubernetes service instead of the `*.pleo.io` address for internal traffic.
+
+We also check for services that needs to change their `securityLevel` settings to `pci-connected`.
+
+## Content of this folder
+
+Scripts for changing URLs:
+- [product-dev.bash](./product-dev.bash)
+- [product-staging.bash](./product-staging.bash)
+- [product-production.bash](./product-production.bash)
+
+Configurations for `multi-gitter`
+- [product-dev.yaml](./product-dev.yaml)
+- [product-staging.yaml](./product-staging.yaml)
+- [product-production.yaml](./product-production.yaml)
+
+## How do we use this?
+
+1. First we get a list of all services running in `product-dev` looking at the list of apps registered in `flux-config`
+2. We run this with `multi-gitter` targeting only the service `ananke` using the `product-dev.yaml` config
+    - comment out the org
+    - comment out the list of repos to only operate on `ananke` for testing purposes
+    - run `multi-gitter run product-dev.bash --config=product-dev.yaml`
+3. We validate that works by merging the PR generated at step 2
+4. We run this against all remaining services in `product-dev`
+5. We merge all PRs and observe for a day
+6. We proceed with `product-staging` generating PRs for all services
+7. We merge all PRs for `product-staging` and we observe for ~2 days
+8. We proceed with `product-production` generating PRs for all services
+7. We merge all PRs for `product-production` and we pray 🙏

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/README.md
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/README.md
@@ -19,14 +19,14 @@ Configurations for `multi-gitter`
 ## How do we use this?
 
 1. First we get a list of all services running in `product-dev` looking at the list of apps registered in `flux-config`
-2. We run this with `multi-gitter` targeting only the service `ananke` using the `product-dev.yaml` config
+2. Run this with `multi-gitter` targeting only the service `ananke` using the `product-dev.yaml` config
     - comment out the org
     - comment out the list of repos to only operate on `ananke` for testing purposes
     - run `multi-gitter run product-dev.bash --config=product-dev.yaml`
-3. We validate that works by merging the PR generated at step 2
-4. We run this against all remaining services in `product-dev`
-5. We merge all PRs and observe for a day
-6. We proceed with `product-staging` generating PRs for all services
-7. We merge all PRs for `product-staging` and we observe for ~2 days
-8. We proceed with `product-production` generating PRs for all services
-7. We merge all PRs for `product-production` and we pray 🙏
+3. Validate that works by merging the PR generated at step 2
+4. Run this against all remaining services in `product-dev`
+5. Merge all PRs and observe for a day
+6. Proceed with `product-staging` generating PRs for all services
+7. Merge all PRs for `product-staging` and observe for ~2 days
+8. Proceed with `product-production` generating PRs for all services
+7. Merge all PRs for `product-production` and pray 🙏

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/README.md
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/README.md
@@ -27,6 +27,8 @@ Configurations for `multi-gitter`
 4. Run this against all remaining services in `product-dev`
 5. Merge all PRs and observe for a day
 6. Proceed with `product-staging` generating PRs for all services
-7. Merge all PRs for `product-staging` and observe for ~2 days
+7. Merge PRs for `product-staging` and observe for ~2 days
+    - don't merge all PRs at once, we merge slowly and observe
 8. Proceed with `product-production` generating PRs for all services
-7. Merge all PRs for `product-production` and pray 🙏
+7. Merge PRs for `product-production` and pray 🙏
+    - don't merge all PRs at once, we merge slowly and observe

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/README.md
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/README.md
@@ -27,7 +27,7 @@ Configurations for `multi-gitter`
 4. Run this against all remaining services in `product-dev`
 5. Merge all PRs and observe for a day
 6. Proceed with `product-staging` generating PRs for all services
-7. Merge PRs for `product-staging` and observe for ~2 days
+7. Merge PRs for `product-staging` and observe for some days
     - don't merge all PRs at once, we merge slowly and observe
 8. Proceed with `product-production` generating PRs for all services
 7. Merge PRs for `product-production` and pray 🙏

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-dev.bash
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-dev.bash
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+function checkSecuritylevel() {
+    local pci_services=("cupid" "dione" "phobos" "scorpio" "titan" "umbriel")
+    for pci_service in "${pci_services[@]}"; do
+        files=($(grep -HRl "https://$pci_service.dev.pleo.io" k8s/product-dev/))
+        echo "all files $files"
+        for file in "${files[@]}"; do
+            find k8s/product-dev -type f -name $(basename $file) -exec sed -i '' -e "s#securityLevel: internal#securityLevel: pci-connected#g" {} +
+        done
+        break
+    done
+}
+
+function changeUrls() {
+    services=("amalthea" "commercial-pricing-calculator" "europa" "kalyke" "pandia" "styx"
+    "ananke" "cordelia" "exportdispatcher" "kari" "pandora" "tarvos"
+    "another-peimos-victor-test" "cupid" "exportlanetracker" "kerberos" "perdita" "taskmanager"
+    "another-peimos" "curiosity" "ganymede" "kustomization" "phobos" "telesto"
+    "ariel" "customer-vulnerability-tracker" "gjoll" "larissa" "phoebe" "thalassa"
+    "auxo" "deimos" "hades" "limit-spend-tracker" "pluto" "thanatos"
+    "backend-service-template" "dione" "hecate" "mab" "prospero" "thebe"
+    "beyond" "dionysus" "henosis" "metis" "puck" "themis"
+    "bookkeepingrules" "dysnomia" "hermes" "mimas" "review-management" "titan"
+    "brokkr" "eirene" "houston" "miranda" "rosalind" "titania"
+    "budgets" "elara" "hr-integrations" "mj-product-demo-one" "scorpio" "triton"
+    "cadmus" "enceladus" "hydra" "mj-product-demo-two" "secretsmanager-backup" "umbriel"
+    "caliban" "endymion" "io" "narvi" "skoll" "uranus"
+    "callisto" "epimetheus" "istio-ingressgateway" "nereid" "spend-projection" "urd"
+    "calypso" "ersa" "janus" "oberon" "spendpolicies"
+    "categorysuggestions" "eunomia" "juliet" "onboarding-playground" "sputnik"
+    "charon" "euporie" "kale" "openbanking-gateway" "strawberry-six"
+    "cicd-improvements-test-service" "europa-bigquery-consumer" "kallichore" "pan" "strawberry-ten")
+
+    for service in "${services[@]}"; do
+        find k8s/product-dev -type f -name "*.yaml" -exec sed -i '' -e "s#https://$service.dev.pleo.io#http://$service.$service#g" {} +
+    done
+
+    find k8s/product-dev -type f -name "*.yaml" -exec sed -i '' -e 's#https://auth.dev.pleo.io#http://kerberos.kerberos#g' {} +
+}
+
+
+if [ -d "k8s" ]; then
+    checkSecuritylevel
+    changeUrls
+fi

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-dev.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-dev.yaml
@@ -96,7 +96,7 @@ pr-body: |
   ## 🤖🤖🤖 This is an automated pull request to switch from using full URLs to k8s services for internal traffic 🤖🤖🤖
   
   In this PR we operate only on `product-dev` and we do the following changes:
-  - change all URLs pointing to internal services to use k8s services instead of full URLs 📍
+  - change host name in all URLs pointing to internal services to use k8s services instead of ingress-nginx-internal URLs 📍
   - if any of the previous URLs were pointing to a PCI service, we also change `securityLevel` to `pci-connected` 🐱‍💻
   
   You can read more on the linear issue [here](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic).

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-dev.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-dev.yaml
@@ -96,7 +96,7 @@ pr-body: |
   ## 🤖🤖🤖 This is an automated pull request to switch from using full URLs to k8s services for internal traffic 🤖🤖🤖
   
   In this PR we operate only on `product-dev` and we do the following changes:
-  - change host name in all URLs pointing to internal services to use k8s services instead of ingress-nginx-internal URLs 📍
+  - change host name in all URLs pointing to internal services to use k8s services instead of `ingress-nginx-internal` URLs 📍
   - if any of the previous URLs were pointing to a PCI service, we also change `securityLevel` to `pci-connected` 🐱‍💻
   
   You can read more on the linear issue [here](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic).

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-dev.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-dev.yaml
@@ -95,7 +95,7 @@ pr-body: |
   
   ## 🤖🤖🤖 This is an automated pull request to switch from using full URLs to k8s services for internal traffic 🤖🤖🤖
   
-  In this PR we operato only on `product-dev` and we do the following changes:
+  In this PR we operate only on `product-dev` and we do the following changes:
   - change all URLs pointing to internal services to use k8s services instead of full URLs 📍
   - if any of the previous URLs were pointing to a PCI service, we also change `securityLevel` to `pci-connected` 🐱‍💻
   

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-dev.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-dev.yaml
@@ -102,7 +102,7 @@ pr-body: |
   You can read more on the linear issue [here](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic).
 
 # The title of the PR. Will default to the first line of the commit message if none is set.
-pr-title: "feat(k8s): [SRE Automated PR] upgrade Datadog monitors"
+pr-title: "feat(k8s): [SRE Automated PR] switch to k8s service in product-dev"
 
 # The name, including owner of a GitHub repository in the format "ownerName/repoName".
 # repo:

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-dev.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-dev.yaml
@@ -1,0 +1,128 @@
+# The username of the assignees to be added on the pull request.
+assignees:
+  - ninjatux
+
+# Email of the committer. If not set, the global git config setting will be used.
+author-email: sre+campaign-bot@pleo.io
+
+# Name of the committer. If not set, the global git config setting will be used.
+author-name: sre-bot
+
+# The branch which the changes will be based on.
+base-branch:
+
+# Base URL of the target platform, needs to be changed for GitHub enterprise, a self-hosted GitLab instance, Gitea or BitBucket.
+base-url:
+
+# The name of the branch where changes are committed.
+branch: feat/sre-5197-product-dev
+
+# Use a code search to find a set of repositories to target (GitHub only). Repeated results from a given repository will be ignored, forks are NOT included by default (use `fork:true` to include them). See the GitHub documentation for full syntax: https://docs.github.com/en/search-github/searching-on-github/searching-code.
+#code-search:
+
+# The commit message. Will default to title + body if none is set.
+commit-message: "fix(k8s): use k8s service instead of full URLs in product-dev"
+
+# The maximum number of concurrent runs.
+concurrent: 1
+
+# What should happen if the branch already exist.
+# Available values:
+#   skip: Skip making any changes to the existing branch and do not create a new pull request.
+#   replace: Replace the existing content of the branch by force pushing any new changes, then reuse any existing pull request, or create a new one if none exist.
+conflict-strategy: replace
+
+# Create pull request(s) as draft.
+draft: false
+
+# Run without pushing changes or creating pull requests.
+dry-run: true
+
+# Limit fetching to the specified number of commits. Set to 0 for no limit.
+fetch-depth: 1
+
+# Fork the repository instead of creating a new branch on the same owner.
+#fork: false
+
+# If set, make the fork to the defined value. Default behavior is for the fork to be on the logged in user.
+#fork-owner:
+
+# The type of git implementation to use.
+# Available values:
+#   go: Uses go-git, a Go native implementation of git. This is compiled with the multi-gitter binary, and no extra dependencies are needed.
+#   cmd: Calls out to the git command. This requires git to be installed and available with by calling "git".
+#git-type: go
+
+# Take manual decision before committing any change. Requires git to be installed.
+interactive: false
+
+# Labels to be added to any created pull request.
+labels:
+  - internal
+  - automerge
+
+# The file where all logs should be printed to. "-" means stdout.
+log-file: "-"
+
+# The formatting of the logs. Available values: text, json, json-pretty.
+log-format: text
+
+# The level of logging that should be made. Available values: trace, debug, info, error.
+log-level: info
+
+# If this value is set, reviewers will be randomized.
+max-reviewers: 0
+
+# If this value is set, team reviewers will be randomized
+max-team-reviewers: 0
+
+# The name of a GitHub organization. All repositories in that organization will be used.
+org:
+  - pleo-io
+
+# The file that the output of the script should be outputted to. "-" means stdout.
+output: "-"
+
+# Don't use any terminal formatting when printing the output.
+plain-output: false
+
+# The platform that is used. Available values: github, gitlab, gitea, bitbucket_server.
+platform: github
+
+# The body of the commit message. Will default to everything but the first line of the commit message if none is set.
+pr-body: |
+  [SRE-5197 : Move from ingress to k8s service for internal traffic](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic)
+  
+  ## 🤖🤖🤖 This is an automated pull request to switch from using full URLs to k8s services for internal traffic 🤖🤖🤖
+  
+  In this PR we operato only on `product-dev` and we do the following changes:
+  - change all URLs pointing to internal services to use k8s services instead of full URLs 📍
+  - if any of the previous URLs were pointing to a PCI service, we also change `securityLevel` to `pci-connected` 🐱‍💻
+  
+  You can read more on the linear issue [here](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic).
+
+# The title of the PR. Will default to the first line of the commit message if none is set.
+pr-title: "feat(k8s): [SRE Automated PR] upgrade Datadog monitors"
+
+# The name, including owner of a GitHub repository in the format "ownerName/repoName".
+# repo:
+#   - pleo-io/ananke
+
+# Exclude repositories that match with a given Regular Expression
+#repo-exclude:
+
+# Include repositories that match with a given Regular Expression
+#repo-include:
+
+# Use a repository search to find repositories to target (GitHub only). Forks are NOT included by default, use `fork:true` to include them. See the GitHub documentation for full syntax: https://docs.github.com/en/search-github/searching-on-github/searching-for-repositories.
+#repo-search:
+
+# The username of the reviewers to be added on the pull request.
+#reviewers:
+#  - example
+
+# Skip repositories which are forks.
+#skip-forks: false
+
+# Skip pull request and directly push to the branch.
+#skip-pr: false

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-production.bash
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-production.bash
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+function checkSecuritylevel() {
+    local pci_services=("cupid" "dione" "phobos" "scorpio" "titan" "umbriel")
+    for pci_service in "${pci_services[@]}"; do
+        files=($(grep -HRl "https://$pci_service.pleo.io" k8s/product-production/))
+        echo "all files $files"
+        for file in "${files[@]}"; do
+            find k8s/product-production -type f -name $(basename $file) -exec sed -i '' -e "s#securityLevel: internal#securityLevel: pci-connected#g" {} +
+        done
+        break
+    done
+}
+
+function changeUrls() {
+    services=("amalthea" "commercial-pricing-calculator" "europa" "kalyke" "pandia" "styx"
+    "ananke" "cordelia" "exportdispatcher" "kari" "pandora" "tarvos"
+    "another-peimos-victor-test" "cupid" "exportlanetracker" "kerberos" "perdita" "taskmanager"
+    "another-peimos" "curiosity" "ganymede" "kustomization" "phobos" "telesto"
+    "ariel" "customer-vulnerability-tracker" "gjoll" "larissa" "phoebe" "thalassa"
+    "auxo" "deimos" "hades" "limit-spend-tracker" "pluto" "thanatos"
+    "backend-service-template" "dione" "hecate" "mab" "prospero" "thebe"
+    "beyond" "dionysus" "henosis" "metis" "puck" "themis"
+    "bookkeepingrules" "dysnomia" "hermes" "mimas" "review-management" "titan"
+    "brokkr" "eirene" "houston" "miranda" "rosalind" "titania"
+    "budgets" "elara" "hr-integrations" "mj-product-demo-one" "scorpio" "triton"
+    "cadmus" "enceladus" "hydra" "mj-product-demo-two" "secretsmanager-backup" "umbriel"
+    "caliban" "endymion" "io" "narvi" "skoll" "uranus"
+    "callisto" "epimetheus" "istio-ingressgateway" "nereid" "spend-projection" "urd"
+    "calypso" "ersa" "janus" "oberon" "spendpolicies"
+    "categorysuggestions" "eunomia" "juliet" "onboarding-playground" "sputnik"
+    "charon" "euporie" "kale" "openbanking-gateway" "strawberry-six"
+    "cicd-improvements-test-service" "europa-bigquery-consumer" "kallichore" "pan" "strawberry-ten")
+
+    for service in "${services[@]}"; do
+        find k8s/product-production -type f -name "*.yaml" -exec sed -i '' -e "s#https://$service.pleo.io#http://$service.$service#g" {} +
+    done
+
+    find k8s/product-production -type f -name "*.yaml" -exec sed -i '' -e 's#https://auth.pleo.io#http://kerberos.kerberos#g' {} +
+}
+
+
+if [ -d "k8s" ]; then
+    checkSecuritylevel
+    changeUrls
+fi

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-production.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-production.yaml
@@ -95,7 +95,7 @@ pr-body: |
   
   ## 🤖🤖🤖 This is an automated pull request to switch from using full URLs to k8s services for internal traffic 🤖🤖🤖
   
-  In this PR we operato only on `product-production` and we do the following changes:
+  In this PR we operate only on `product-production` and we do the following changes:
   - change all URLs pointing to internal services to use k8s services instead of full URLs 📍
   - if any of the previous URLs were pointing to a PCI service, we also change `securityLevel` to `pci-connected` 🐱‍💻
   

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-production.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-production.yaml
@@ -96,7 +96,7 @@ pr-body: |
   ## 🤖🤖🤖 This is an automated pull request to switch from using full URLs to k8s services for internal traffic 🤖🤖🤖
   
   In this PR we operate only on `product-production` and we do the following changes:
-  - change all URLs pointing to internal services to use k8s services instead of full URLs 📍
+  - change host name in all URLs pointing to internal services to use k8s services instead of `ingress-nginx-internal` URLs 📍
   - if any of the previous URLs were pointing to a PCI service, we also change `securityLevel` to `pci-connected` 🐱‍💻
   
   You can read more on the linear issue [here](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic).

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-production.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-production.yaml
@@ -21,7 +21,7 @@ branch: feat/sre-5197-product-production
 #code-search:
 
 # The commit message. Will default to title + body if none is set.
-commit-message: "fix(k8s): use k8s service instead of full URLs in product-dev"
+commit-message: "fix(k8s): use k8s service instead of full URLs in product-production"
 
 # The maximum number of concurrent runs.
 concurrent: 1
@@ -102,7 +102,7 @@ pr-body: |
   You can read more on the linear issue [here](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic).
 
 # The title of the PR. Will default to the first line of the commit message if none is set.
-pr-title: "feat(k8s): [SRE Automated PR] upgrade Datadog monitors"
+pr-title: "feat(k8s): [SRE Automated PR] switch to k8s service in product-production"
 
 # The name, including owner of a GitHub repository in the format "ownerName/repoName".
 # we want to use `nanake` for testing

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-production.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-production.yaml
@@ -1,0 +1,129 @@
+# The username of the assignees to be added on the pull request.
+assignees:
+  - ninjatux
+
+# Email of the committer. If not set, the global git config setting will be used.
+author-email: sre+campaign-bot@pleo.io
+
+# Name of the committer. If not set, the global git config setting will be used.
+author-name: sre-bot
+
+# The branch which the changes will be based on.
+base-branch:
+
+# Base URL of the target platform, needs to be changed for GitHub enterprise, a self-hosted GitLab instance, Gitea or BitBucket.
+base-url:
+
+# The name of the branch where changes are committed.
+branch: feat/sre-5197-product-production
+
+# Use a code search to find a set of repositories to target (GitHub only). Repeated results from a given repository will be ignored, forks are NOT included by default (use `fork:true` to include them). See the GitHub documentation for full syntax: https://docs.github.com/en/search-github/searching-on-github/searching-code.
+#code-search:
+
+# The commit message. Will default to title + body if none is set.
+commit-message: "fix(k8s): use k8s service instead of full URLs in product-dev"
+
+# The maximum number of concurrent runs.
+concurrent: 1
+
+# What should happen if the branch already exist.
+# Available values:
+#   skip: Skip making any changes to the existing branch and do not create a new pull request.
+#   replace: Replace the existing content of the branch by force pushing any new changes, then reuse any existing pull request, or create a new one if none exist.
+conflict-strategy: replace
+
+# Create pull request(s) as draft.
+draft: false
+
+# Run without pushing changes or creating pull requests.
+dry-run: true
+
+# Limit fetching to the specified number of commits. Set to 0 for no limit.
+fetch-depth: 1
+
+# Fork the repository instead of creating a new branch on the same owner.
+#fork: false
+
+# If set, make the fork to the defined value. Default behavior is for the fork to be on the logged in user.
+#fork-owner:
+
+# The type of git implementation to use.
+# Available values:
+#   go: Uses go-git, a Go native implementation of git. This is compiled with the multi-gitter binary, and no extra dependencies are needed.
+#   cmd: Calls out to the git command. This requires git to be installed and available with by calling "git".
+#git-type: go
+
+# Take manual decision before committing any change. Requires git to be installed.
+interactive: false
+
+# Labels to be added to any created pull request.
+labels:
+  - internal
+  - automerge
+
+# The file where all logs should be printed to. "-" means stdout.
+log-file: "-"
+
+# The formatting of the logs. Available values: text, json, json-pretty.
+log-format: text
+
+# The level of logging that should be made. Available values: trace, debug, info, error.
+log-level: info
+
+# If this value is set, reviewers will be randomized.
+max-reviewers: 0
+
+# If this value is set, team reviewers will be randomized
+max-team-reviewers: 0
+
+# The name of a GitHub organization. All repositories in that organization will be used.
+org:
+  - pleo-io
+
+# The file that the output of the script should be outputted to. "-" means stdout.
+output: "-"
+
+# Don't use any terminal formatting when printing the output.
+plain-output: false
+
+# The platform that is used. Available values: github, gitlab, gitea, bitbucket_server.
+platform: github
+
+# The body of the commit message. Will default to everything but the first line of the commit message if none is set.
+pr-body: |
+  [SRE-5197 : Move from ingress to k8s service for internal traffic](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic)
+  
+  ## 🤖🤖🤖 This is an automated pull request to switch from using full URLs to k8s services for internal traffic 🤖🤖🤖
+  
+  In this PR we operato only on `product-production` and we do the following changes:
+  - change all URLs pointing to internal services to use k8s services instead of full URLs 📍
+  - if any of the previous URLs were pointing to a PCI service, we also change `securityLevel` to `pci-connected` 🐱‍💻
+  
+  You can read more on the linear issue [here](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic).
+
+# The title of the PR. Will default to the first line of the commit message if none is set.
+pr-title: "feat(k8s): [SRE Automated PR] upgrade Datadog monitors"
+
+# The name, including owner of a GitHub repository in the format "ownerName/repoName".
+# we want to use `nanake` for testing
+# repo:
+#   - pleo-io/ananke
+
+# Exclude repositories that match with a given Regular Expression
+#repo-exclude:
+
+# Include repositories that match with a given Regular Expression
+#repo-include:
+
+# Use a repository search to find repositories to target (GitHub only). Forks are NOT included by default, use `fork:true` to include them. See the GitHub documentation for full syntax: https://docs.github.com/en/search-github/searching-on-github/searching-for-repositories.
+#repo-search:
+
+# The username of the reviewers to be added on the pull request.
+#reviewers:
+#  - example
+
+# Skip repositories which are forks.
+#skip-forks: false
+
+# Skip pull request and directly push to the branch.
+#skip-pr: false

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-staging.bash
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-staging.bash
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+function checkSecuritylevel() {
+    local pci_services=("cupid" "dione" "phobos" "scorpio" "titan" "umbriel")
+    for pci_service in "${pci_services[@]}"; do
+        files=($(grep -HRl "https://$pci_service.staging.pleo.io" k8s/product-staging/))
+        echo "all files $files"
+        for file in "${files[@]}"; do
+            find k8s/product-staging -type f -name $(basename $file) -exec sed -i '' -e "s#securityLevel: internal#securityLevel: pci-connected#g" {} +
+        done
+        break
+    done
+}
+
+function changeUrls() {
+    services=("amalthea" "commercial-pricing-calculator" "europa" "kalyke" "pandia" "styx"
+    "ananke" "cordelia" "exportdispatcher" "kari" "pandora" "tarvos"
+    "another-peimos-victor-test" "cupid" "exportlanetracker" "kerberos" "perdita" "taskmanager"
+    "another-peimos" "curiosity" "ganymede" "kustomization" "phobos" "telesto"
+    "ariel" "customer-vulnerability-tracker" "gjoll" "larissa" "phoebe" "thalassa"
+    "auxo" "deimos" "hades" "limit-spend-tracker" "pluto" "thanatos"
+    "backend-service-template" "dione" "hecate" "mab" "prospero" "thebe"
+    "beyond" "dionysus" "henosis" "metis" "puck" "themis"
+    "bookkeepingrules" "dysnomia" "hermes" "mimas" "review-management" "titan"
+    "brokkr" "eirene" "houston" "miranda" "rosalind" "titania"
+    "budgets" "elara" "hr-integrations" "mj-product-demo-one" "scorpio" "triton"
+    "cadmus" "enceladus" "hydra" "mj-product-demo-two" "secretsmanager-backup" "umbriel"
+    "caliban" "endymion" "io" "narvi" "skoll" "uranus"
+    "callisto" "epimetheus" "istio-ingressgateway" "nereid" "spend-projection" "urd"
+    "calypso" "ersa" "janus" "oberon" "spendpolicies"
+    "categorysuggestions" "eunomia" "juliet" "onboarding-playground" "sputnik"
+    "charon" "euporie" "kale" "openbanking-gateway" "strawberry-six"
+    "cicd-improvements-test-service" "europa-bigquery-consumer" "kallichore" "pan" "strawberry-ten")
+
+    for service in "${services[@]}"; do
+        find k8s/product-staging -type f -name "*.yaml" -exec sed -i '' -e "s#https://$service.staging.pleo.io#http://$service.$service#g" {} +
+    done
+
+    find k8s/product-staging -type f -name "*.yaml" -exec sed -i '' -e 's#https://auth.staging.pleo.io#http://kerberos.kerberos#g' {} +
+}
+
+
+if [ -d "k8s" ]; then
+    checkSecuritylevel
+    changeUrls
+fi

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-staging.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-staging.yaml
@@ -96,7 +96,7 @@ pr-body: |
   ## 🤖🤖🤖 This is an automated pull request to switch from using full URLs to k8s services for internal traffic 🤖🤖🤖
   
   In this PR we operate only on `product-staging` and we do the following changes:
-  - change all URLs pointing to internal services to use k8s services instead of full URLs 📍
+  - change host name in all URLs pointing to internal services to use k8s services instead of `ingress-nginx-internal` URLs 📍
   - if any of the previous URLs were pointing to a PCI service, we also change `securityLevel` to `pci-connected` 🐱‍💻
   
   You can read more on the linear issue [here](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic).

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-staging.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-staging.yaml
@@ -1,0 +1,129 @@
+# The username of the assignees to be added on the pull request.
+assignees:
+  - ninjatux
+
+# Email of the committer. If not set, the global git config setting will be used.
+author-email: sre+campaign-bot@pleo.io
+
+# Name of the committer. If not set, the global git config setting will be used.
+author-name: sre-bot
+
+# The branch which the changes will be based on.
+base-branch:
+
+# Base URL of the target platform, needs to be changed for GitHub enterprise, a self-hosted GitLab instance, Gitea or BitBucket.
+base-url:
+
+# The name of the branch where changes are committed.
+branch: feat/sre-5197-product-staging
+
+# Use a code search to find a set of repositories to target (GitHub only). Repeated results from a given repository will be ignored, forks are NOT included by default (use `fork:true` to include them). See the GitHub documentation for full syntax: https://docs.github.com/en/search-github/searching-on-github/searching-code.
+#code-search:
+
+# The commit message. Will default to title + body if none is set.
+commit-message: "fix(k8s): use k8s service instead of full URLs in product-dev"
+
+# The maximum number of concurrent runs.
+concurrent: 1
+
+# What should happen if the branch already exist.
+# Available values:
+#   skip: Skip making any changes to the existing branch and do not create a new pull request.
+#   replace: Replace the existing content of the branch by force pushing any new changes, then reuse any existing pull request, or create a new one if none exist.
+conflict-strategy: replace
+
+# Create pull request(s) as draft.
+draft: false
+
+# Run without pushing changes or creating pull requests.
+dry-run: true
+
+# Limit fetching to the specified number of commits. Set to 0 for no limit.
+fetch-depth: 1
+
+# Fork the repository instead of creating a new branch on the same owner.
+#fork: false
+
+# If set, make the fork to the defined value. Default behavior is for the fork to be on the logged in user.
+#fork-owner:
+
+# The type of git implementation to use.
+# Available values:
+#   go: Uses go-git, a Go native implementation of git. This is compiled with the multi-gitter binary, and no extra dependencies are needed.
+#   cmd: Calls out to the git command. This requires git to be installed and available with by calling "git".
+#git-type: go
+
+# Take manual decision before committing any change. Requires git to be installed.
+interactive: false
+
+# Labels to be added to any created pull request.
+labels:
+  - internal
+  - automerge
+
+# The file where all logs should be printed to. "-" means stdout.
+log-file: "-"
+
+# The formatting of the logs. Available values: text, json, json-pretty.
+log-format: text
+
+# The level of logging that should be made. Available values: trace, debug, info, error.
+log-level: info
+
+# If this value is set, reviewers will be randomized.
+max-reviewers: 0
+
+# If this value is set, team reviewers will be randomized
+max-team-reviewers: 0
+
+# The name of a GitHub organization. All repositories in that organization will be used.
+# org:
+#   - pleo-io
+
+# The file that the output of the script should be outputted to. "-" means stdout.
+output: "-"
+
+# Don't use any terminal formatting when printing the output.
+plain-output: false
+
+# The platform that is used. Available values: github, gitlab, gitea, bitbucket_server.
+platform: github
+
+# The body of the commit message. Will default to everything but the first line of the commit message if none is set.
+pr-body: |
+  [SRE-5197 : Move from ingress to k8s service for internal traffic](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic)
+  
+  ## 🤖🤖🤖 This is an automated pull request to switch from using full URLs to k8s services for internal traffic 🤖🤖🤖
+  
+  In this PR we operato only on `product-staging` and we do the following changes:
+  - change all URLs pointing to internal services to use k8s services instead of full URLs 📍
+  - if any of the previous URLs were pointing to a PCI service, we also change `securityLevel` to `pci-connected` 🐱‍💻
+  
+  You can read more on the linear issue [here](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic).
+
+# The title of the PR. Will default to the first line of the commit message if none is set.
+pr-title: "feat(k8s): [SRE Automated PR] upgrade Datadog monitors"
+
+# The name, including owner of a GitHub repository in the format "ownerName/repoName".
+# we want to use `nanake` for testing
+# repo:
+#   - pleo-io/ananke
+
+# Exclude repositories that match with a given Regular Expression
+#repo-exclude:
+
+# Include repositories that match with a given Regular Expression
+#repo-include:
+
+# Use a repository search to find repositories to target (GitHub only). Forks are NOT included by default, use `fork:true` to include them. See the GitHub documentation for full syntax: https://docs.github.com/en/search-github/searching-on-github/searching-for-repositories.
+#repo-search:
+
+# The username of the reviewers to be added on the pull request.
+#reviewers:
+#  - example
+
+# Skip repositories which are forks.
+#skip-forks: false
+
+# Skip pull request and directly push to the branch.
+#skip-pr: false

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-staging.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-staging.yaml
@@ -95,7 +95,7 @@ pr-body: |
   
   ## 🤖🤖🤖 This is an automated pull request to switch from using full URLs to k8s services for internal traffic 🤖🤖🤖
   
-  In this PR we operato only on `product-staging` and we do the following changes:
+  In this PR we operate only on `product-staging` and we do the following changes:
   - change all URLs pointing to internal services to use k8s services instead of full URLs 📍
   - if any of the previous URLs were pointing to a PCI service, we also change `securityLevel` to `pci-connected` 🐱‍💻
   

--- a/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-staging.yaml
+++ b/scripts/sre-5197-switch-from-ingress-to-k8s-service/product-staging.yaml
@@ -21,7 +21,7 @@ branch: feat/sre-5197-product-staging
 #code-search:
 
 # The commit message. Will default to title + body if none is set.
-commit-message: "fix(k8s): use k8s service instead of full URLs in product-dev"
+commit-message: "fix(k8s): use k8s service instead of full URLs in product-staging"
 
 # The maximum number of concurrent runs.
 concurrent: 1
@@ -102,7 +102,7 @@ pr-body: |
   You can read more on the linear issue [here](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic).
 
 # The title of the PR. Will default to the first line of the commit message if none is set.
-pr-title: "feat(k8s): [SRE Automated PR] upgrade Datadog monitors"
+pr-title: "feat(k8s): [SRE Automated PR] switch to k8s service in product-staging"
 
 # The name, including owner of a GitHub repository in the format "ownerName/repoName".
 # we want to use `nanake` for testing


### PR DESCRIPTION
This PRs will adds scripts used for [SRE-5197 : Move from ingress to k8s service for internal traffic](https://linear.app/pleo/issue/SRE-5197/move-from-ingress-to-k8s-service-for-internal-traffic) with `multi-gitter`.

The execution plan is outlined in the README