### PR TITLE
feat(SRE-5553): rename owner

### DIFF
--- a/opslevel.yml
+++ b/opslevel.yml
@@ -1,9 +1,9 @@
 ---
 version: 1
 service:
-  name: SRE Tools
+  name: sre tools
   lifecycle: alpha
-  owner: site-reliability-engineering
+  owner: team-site-reliability-engineering
   language: Shell
   description: |-
     Misc stuff to help with various SRE stuff

--- a/opslevel.yml
+++ b/opslevel.yml
@@ -1,7 +1,7 @@
 ---
 version: 1
 service:
-  name: sre tools
+  name: SRE Tools
   lifecycle: alpha
   owner: team-site-reliability-engineering
   language: Shell

--- a/opslevel.yml
+++ b/opslevel.yml
@@ -3,7 +3,7 @@ version: 1
 service:
   name: SRE Tools
   lifecycle: alpha
-  owner: sre
+  owner: site-reliability-engineering
   language: Shell
   description: |-
     Misc stuff to help with various SRE stuff


### PR DESCRIPTION
https://linear.app/pleo/issue/SRE-5553/switch-owner-tag-on-sre-owned-repository-to-site-reliability

The `sre` owner tag seems to get removed automatically sometimes leading to the OpsLevel ownership link not working very well. Let's use another owner tag `site-reliability-engineering`.